### PR TITLE
[chore] 오라클 NUMBER(1) ↔ 자바 boolean 변환 핸들러 생성

### DIFF
--- a/src/main/java/com/final_team4/finalbe/_core/config/mybatis/BooleanFlagTypeHandler.java
+++ b/src/main/java/com/final_team4/finalbe/_core/config/mybatis/BooleanFlagTypeHandler.java
@@ -1,0 +1,44 @@
+package com.final_team4.finalbe._core.config.mybatis;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@MappedTypes(Boolean.class)
+@MappedJdbcTypes(JdbcType.NUMERIC)
+public class BooleanFlagTypeHandler extends BaseTypeHandler<Boolean> {
+
+  // DB insert/update 시 boolean → NUMBER(1)로 변환
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, Boolean parameter, JdbcType jdbcType)
+      throws SQLException {
+    ps.setInt(i, parameter ? 1 : 0);
+  }
+
+  // 컬럼명을 기준으로 조회한 NUMBER(1)을 boolean으로 변환
+  @Override
+  public Boolean getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    int value = rs.getInt(columnName);
+    return !rs.wasNull() && value == 1;
+  }
+
+  // 컬럼 인덱스를 기준으로 조회한 NUMBER(1)을 boolean으로 변환
+  @Override
+  public Boolean getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    int value = rs.getInt(columnIndex);
+    return !rs.wasNull() && value == 1;
+  }
+
+  // 프로시저 호출 결과 NUMBER(1)을 boolean으로 변환
+  @Override
+  public Boolean getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    int value = cs.getInt(columnIndex);
+    return !cs.wasNull() && value == 1;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ mybatis:
 
   # alias 설정 추가하려면 ,로 구분
   type-aliases-package: com.final_team4.finalbe.*.domain
+  type-handlers-package: com.final_team4.finalbe._core.config.mybatis
 
   # camelCase ↔ snake_case 자동 변환
   configuration:


### PR DESCRIPTION
## 🐰 Issue
> 닫을 issue 번호를 적어주세요.

resolved #37
<br>


## 🐷 Key Changes
> issue 이외의 변경 사항을 명시해주세요.
1. 오라클 NUMBER(1) ↔ 자바 boolean 변환 핸들러 생성 
<br>


## 🐱 Branch

feat-37 -> dev
<br>


## 🐲 To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.
1. 오라클 NUMBER(1) ↔ 자바 boolean 매핑을 위해 BooleanFlagTypeHandler 클래스를 만들었습니다.
2. MyBatis가 ResultSet/PreparedStatement에 값을 넣고 빼는 단계에서 BooleanFlagTypeHandler를 자동으로 호출합니다.
3. application.yml에 type-handlers-package: com.final_team4.finalbe._core.config.mybatis를 등록해 두었기 때문에 해당 패키지에 있는 BooleanFlagTypeHandler가 전역으로 적용됩니다.
4. BooleanFlagTypeHandler에서 BaseTypeHandler를 상속하며 @MappedTypes(Boolean.class)로 “Boolean 타입을 다룰 때 나를 써라”라고 선언했습니다.
5. 그 결과 MyBatis가 UploadChannel.status 필드를 매핑하려고 할 때 자동으로 핸들러를 사용해 DB의 NUMBER(1) ↔ 자바 Boolean을 변환합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 불리언 필드 처리 방식을 개선하여 숫자 형식의 저장소와의 호환성을 강화했습니다. 이를 통해 불리언 값의 저장 및 조회 신뢰성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->