### PR TITLE
[fix] llmChannel 테이블에 generationType 속성 추가

### DIFF
--- a/src/main/java/com/final_team4/finalbe/setting/domain/llm/LlmChannel.java
+++ b/src/main/java/com/final_team4/finalbe/setting/domain/llm/LlmChannel.java
@@ -1,5 +1,6 @@
 package com.final_team4.finalbe.setting.domain.llm;
 
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -19,11 +20,12 @@ public class LlmChannel {
     private Integer maxTokens;
     private BigDecimal temperature;
     private String prompt; // CLOB 타입
+    private ContentGenType generationType; // 자동생성/수동생성
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public void update(String name, String modelName, String apiKey, 
-                      Boolean status, Integer maxTokens, BigDecimal temperature, String prompt) {
+                      Boolean status, Integer maxTokens, BigDecimal temperature, String prompt, ContentGenType generationType) {
         if (name != null) this.name = name;
         if (modelName != null) this.modelName = modelName;
         if (apiKey != null) this.apiKey = apiKey;
@@ -31,6 +33,7 @@ public class LlmChannel {
         if (maxTokens != null) this.maxTokens = maxTokens;
         if (temperature != null) this.temperature = temperature;
         if (prompt != null) this.prompt = prompt;
+        if (generationType != null) this.generationType = generationType;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/final_team4/finalbe/setting/dto/llm/LlmChannelCreateRequestDto.java
+++ b/src/main/java/com/final_team4/finalbe/setting/dto/llm/LlmChannelCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.final_team4.finalbe.setting.dto.llm;
 
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
@@ -42,6 +43,9 @@ public class LlmChannelCreateRequestDto {
     private BigDecimal temperature;
 
     private String prompt; // CLOB 타입 (긴 텍스트)
+
+    @NotNull
+    private ContentGenType generationType; // 자동생성/수동생성
     
     // 주의: userId는 보안상 Request Body에 포함하지 않고, 
     // 컨트롤러에서 @AuthenticationPrincipal로 주입받아 사용

--- a/src/main/java/com/final_team4/finalbe/setting/dto/llm/LlmChannelDetailResponseDto.java
+++ b/src/main/java/com/final_team4/finalbe/setting/dto/llm/LlmChannelDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.final_team4.finalbe.setting.dto.llm;
 
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import com.final_team4.finalbe.setting.domain.llm.LlmChannel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class LlmChannelDetailResponseDto {
     private BigDecimal temperature;
     private String prompt; // CLOB 타입
     private String apiKey; // 마스킹 처리된 값
+    private ContentGenType generationType; // 자동생성/수동생성
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -33,6 +35,7 @@ public class LlmChannelDetailResponseDto {
                 .temperature(entity.getTemperature())
                 .prompt(entity.getPrompt())
                 .apiKey(maskApiKey(entity.getApiKey()))
+                .generationType(entity.getGenerationType())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();

--- a/src/main/java/com/final_team4/finalbe/setting/dto/llm/LlmChannelUpdateRequestDto.java
+++ b/src/main/java/com/final_team4/finalbe/setting/dto/llm/LlmChannelUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.final_team4.finalbe.setting.dto.llm;
 
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
@@ -37,6 +38,9 @@ public class LlmChannelUpdateRequestDto {
     private BigDecimal temperature;
 
     private String prompt; // CLOB 타입 (긴 텍스트)
+
+    @NotNull
+    private ContentGenType generationType; // 자동생성/수동생성
     
     // 주의: userId는 보안상 Request Body에 포함하지 않고, 
     // 컨트롤러에서 @AuthenticationPrincipal로 주입받아 사용

--- a/src/main/java/com/final_team4/finalbe/setting/service/llm/LlmChannelService.java
+++ b/src/main/java/com/final_team4/finalbe/setting/service/llm/LlmChannelService.java
@@ -73,7 +73,8 @@ public class LlmChannelService {
                 requestDto.getStatus(),
                 requestDto.getMaxTokens(),
                 requestDto.getTemperature(),
-                requestDto.getPrompt()
+                requestDto.getPrompt(),
+                requestDto.getGenerationType()
         );
 
         llmChannelMapper.update(entity);
@@ -128,6 +129,7 @@ public class LlmChannelService {
                 .maxTokens(maxTokens)
                 .temperature(temperature)
                 .prompt(requestDto.getPrompt())
+                .generationType(requestDto.getGenerationType())
                 .createdAt(now)
                 .updatedAt(now)
                 .build();

--- a/src/main/java/com/final_team4/finalbe/user/service/UserService.java
+++ b/src/main/java/com/final_team4/finalbe/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.final_team4.finalbe.user.service;
 import com.final_team4.finalbe._core.exception.ContentNotFoundException;
 import com.final_team4.finalbe._core.exception.DuplicateEmailException;
 import com.final_team4.finalbe._core.exception.UnauthorizedException;
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import com.final_team4.finalbe.schedule.dto.scheduleSetting.ScheduleSettingCreateRequestDto;
 import com.final_team4.finalbe.schedule.service.ScheduleSettingService;
 import com.final_team4.finalbe.setting.dto.llm.LlmChannelCreateRequestDto;
@@ -65,6 +66,7 @@ public class UserService {
                 .maxTokens(2000)
                 .temperature(BigDecimal.valueOf(0.9))
                 .prompt("설정 필요")
+                .generationType(ContentGenType.AUTO)
                 .build();
         llmChannelService.create(user.getId(), defaultLlmSetting);
         //llm 기본값 채워주기

--- a/src/main/resources/db/migration/V11__add_generation_type_to_llm_channel.sql
+++ b/src/main/resources/db/migration/V11__add_generation_type_to_llm_channel.sql
@@ -1,0 +1,4 @@
+-- LLM 채널 테이블에 GENERATION_TYPE 컬럼 추가
+ALTER TABLE llm_channel
+ADD generation_type VARCHAR2(20) DEFAULT 'AUTO' NOT NULL;
+

--- a/src/main/resources/mapper/setting/llm/LlmChannelMapper.xml
+++ b/src/main/resources/mapper/setting/llm/LlmChannelMapper.xml
@@ -14,6 +14,7 @@
         MAX_TOKENS,
         TEMPERATURE,
         PROMPT,
+        GENERATION_TYPE,
         CREATED_AT,
         UPDATED_AT
     </sql>
@@ -50,6 +51,7 @@
             MAX_TOKENS = #{maxTokens},
             TEMPERATURE = #{temperature},
             PROMPT = #{prompt},
+            GENERATION_TYPE = #{generationType},
             UPDATED_AT = SYSTIMESTAMP
         WHERE
             ID = #{id} AND 
@@ -67,6 +69,7 @@
                 MAX_TOKENS,
                 TEMPERATURE,
                 PROMPT,
+                GENERATION_TYPE,
                 CREATED_AT,
                 UPDATED_AT
         )
@@ -79,6 +82,7 @@
                 #{maxTokens},
                 #{temperature},
                 #{prompt},
+                #{generationType},
                 SYSTIMESTAMP,
                 SYSTIMESTAMP
             )

--- a/src/test/java/com/final_team4/finalbe/setting/controller/llm/LlmChannelControllerTest.java
+++ b/src/test/java/com/final_team4/finalbe/setting/controller/llm/LlmChannelControllerTest.java
@@ -4,6 +4,7 @@ import com.final_team4.finalbe._core.config.GlobalExceptionHandler;
 import com.final_team4.finalbe._core.exception.ContentNotFoundException;
 import com.final_team4.finalbe._core.security.JwtPrincipal;
 import com.final_team4.finalbe._core.exception.BadRequestException;
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import com.final_team4.finalbe.setting.dto.llm.LlmChannelCreateRequestDto;
 import com.final_team4.finalbe.setting.dto.llm.LlmChannelDetailResponseDto;
 import com.final_team4.finalbe.setting.dto.llm.LlmChannelUpdateRequestDto;
@@ -104,6 +105,7 @@ class LlmChannelControllerTest {
         .maxTokens(2000)
         .temperature(new BigDecimal("0.7"))
         .apiKey("****************1234")
+        .generationType(ContentGenType.AUTO)
         .createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())
         .build();
@@ -121,7 +123,8 @@ class LlmChannelControllerTest {
         .andExpect(jsonPath("$.modelName").value("gpt-4"))
         .andExpect(jsonPath("$.maxTokens").value(2000))
         .andExpect(jsonPath("$.temperature").value(0.7))
-        .andExpect(jsonPath("$.status").value(true));
+        .andExpect(jsonPath("$.status").value(true))
+        .andExpect(jsonPath("$.generationType").value("AUTO"));
 
     verify(llmChannelService).findByUserId(userId);
   }
@@ -165,6 +168,7 @@ class LlmChannelControllerTest {
         .maxTokens(2000)
         .temperature(new BigDecimal("0.7"))
         .prompt("You are a helpful assistant.")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     LlmChannelDetailResponseDto responseDto = LlmChannelDetailResponseDto.builder()
@@ -177,6 +181,7 @@ class LlmChannelControllerTest {
         .temperature(new BigDecimal("0.7"))
         .prompt("You are a helpful assistant.")
         .apiKey("****************5678")
+        .generationType(ContentGenType.AUTO)
         .createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())
         .build();
@@ -197,7 +202,8 @@ class LlmChannelControllerTest {
         .andExpect(jsonPath("$.maxTokens").value(2000))
         .andExpect(jsonPath("$.temperature").value(0.7))
         .andExpect(jsonPath("$.prompt").value("You are a helpful assistant."))
-        .andExpect(jsonPath("$.status").value(true));
+        .andExpect(jsonPath("$.status").value(true))
+        .andExpect(jsonPath("$.generationType").value("AUTO"));
 
     verify(llmChannelService).create(eq(userId), any(LlmChannelCreateRequestDto.class));
   }
@@ -210,6 +216,7 @@ class LlmChannelControllerTest {
         .name("Test LLM")
         .modelName("gpt-4")
         .apiKey("sk-test-key")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when & then
@@ -230,6 +237,7 @@ class LlmChannelControllerTest {
         // name이 null (필수 필드)
         .modelName("gpt-4")
         .apiKey("sk-test-key")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when & then
@@ -251,6 +259,7 @@ class LlmChannelControllerTest {
         .name("Test LLM")
         // modelName이 null (필수 필드)
         .apiKey("sk-test-key")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when & then
@@ -271,6 +280,7 @@ class LlmChannelControllerTest {
     LlmChannelCreateRequestDto requestDto = LlmChannelCreateRequestDto.builder()
         .name("Test LLM")
         .modelName("gpt-4")
+        .generationType(ContentGenType.AUTO)
         // apiKey가 null (비즈니스 로직 검증)
         .build();
 
@@ -299,6 +309,7 @@ class LlmChannelControllerTest {
         .name("Test LLM")
         .modelName("gpt-4")
         .apiKey("sk-test-key-12345678")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     given(llmChannelService.create(eq(userId), any(LlmChannelCreateRequestDto.class)))
@@ -330,6 +341,7 @@ class LlmChannelControllerTest {
         .maxTokens(3000)
         .temperature(new BigDecimal("0.85"))
         .prompt("Updated prompt")
+        .generationType(ContentGenType.MANUAL)
         .build();
 
     LlmChannelDetailResponseDto responseDto = LlmChannelDetailResponseDto.builder()
@@ -342,6 +354,7 @@ class LlmChannelControllerTest {
         .temperature(new BigDecimal("0.85"))
         .prompt("Updated prompt")
         .apiKey("****************1234")
+        .generationType(ContentGenType.MANUAL)
         .createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())
         .build();
@@ -362,7 +375,8 @@ class LlmChannelControllerTest {
         .andExpect(jsonPath("$.maxTokens").value(3000))
         .andExpect(jsonPath("$.temperature").value(0.85))
         .andExpect(jsonPath("$.prompt").value("Updated prompt"))
-        .andExpect(jsonPath("$.status").value(true));
+        .andExpect(jsonPath("$.status").value(true))
+        .andExpect(jsonPath("$.generationType").value("MANUAL"));
 
     verify(llmChannelService).update(eq(userId), any(LlmChannelUpdateRequestDto.class));
   }
@@ -373,6 +387,7 @@ class LlmChannelControllerTest {
     // given
     LlmChannelUpdateRequestDto requestDto = LlmChannelUpdateRequestDto.builder()
         .modelName("gpt-4")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when & then
@@ -391,6 +406,7 @@ class LlmChannelControllerTest {
 
     LlmChannelUpdateRequestDto requestDto = LlmChannelUpdateRequestDto.builder()
         .name("Test")
+        .generationType(ContentGenType.AUTO)
         // modelName이 null (필수 필드)
         .build();
 
@@ -411,6 +427,7 @@ class LlmChannelControllerTest {
 
     LlmChannelUpdateRequestDto requestDto = LlmChannelUpdateRequestDto.builder()
         .modelName("gpt-4")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     given(llmChannelService.update(eq(userId), any(LlmChannelUpdateRequestDto.class)))
@@ -434,7 +451,8 @@ class LlmChannelControllerTest {
     String requestBody = """
         {
           "modelName": "gpt-4",
-          "temperature": 3.0
+          "temperature": 3.0,
+          "generationType": "AUTO"
         }
         """;
 

--- a/src/test/java/com/final_team4/finalbe/setting/service/llm/LlmChannelServiceTest.java
+++ b/src/test/java/com/final_team4/finalbe/setting/service/llm/LlmChannelServiceTest.java
@@ -2,6 +2,7 @@ package com.final_team4.finalbe.setting.service.llm;
 
 import com.final_team4.finalbe._core.exception.BadRequestException;
 import com.final_team4.finalbe._core.exception.ContentNotFoundException;
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import com.final_team4.finalbe.setting.domain.llm.LlmChannel;
 import com.final_team4.finalbe.setting.dto.llm.LlmChannelCreateRequestDto;
 import com.final_team4.finalbe.setting.dto.llm.LlmChannelDetailResponseDto;
@@ -77,6 +78,7 @@ class LlmChannelServiceTest {
         .maxTokens(3000)
         .temperature(new BigDecimal("0.85"))
         .prompt("Updated prompt")
+        .generationType(ContentGenType.MANUAL)
         .build();
 
     // when
@@ -90,6 +92,7 @@ class LlmChannelServiceTest {
     assertThat(result.getTemperature()).isEqualByComparingTo(new BigDecimal("0.85"));
     assertThat(result.getStatus()).isTrue();
     assertThat(result.getPrompt()).isEqualTo("Updated prompt");
+    assertThat(result.getGenerationType()).isEqualTo(ContentGenType.MANUAL);
   }
 
   @DisplayName("성공_LLM 설정 부분 수정 (일부 필드만 업데이트)")
@@ -103,6 +106,7 @@ class LlmChannelServiceTest {
         .name("Partially Updated")
         .modelName("gpt-4")
         .maxTokens(2500)
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when
@@ -113,6 +117,7 @@ class LlmChannelServiceTest {
     assertThat(result.getName()).isEqualTo("Partially Updated");
     assertThat(result.getModelName()).isEqualTo("gpt-4");
     assertThat(result.getMaxTokens()).isEqualTo(2500);
+    assertThat(result.getGenerationType()).isEqualTo(ContentGenType.AUTO);
     // 기존 값 유지 확인
     assertThat(result.getTemperature()).isEqualByComparingTo(new BigDecimal("0.7"));
   }
@@ -124,6 +129,7 @@ class LlmChannelServiceTest {
     Long nonExistentUserId = 999L;
     LlmChannelUpdateRequestDto updateRequest = LlmChannelUpdateRequestDto.builder()
         .modelName("gpt-4")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when & then
@@ -174,6 +180,7 @@ class LlmChannelServiceTest {
         .maxTokens(2000)
         .temperature(new BigDecimal("0.7"))
         .prompt("You are a helpful assistant.")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when
@@ -189,12 +196,14 @@ class LlmChannelServiceTest {
     assertThat(result.getMaxTokens()).isEqualTo(2000);
     assertThat(result.getTemperature()).isEqualByComparingTo(new BigDecimal("0.7"));
     assertThat(result.getPrompt()).isEqualTo("You are a helpful assistant.");
+    assertThat(result.getGenerationType()).isEqualTo(ContentGenType.AUTO);
 
     // DB에 실제로 저장되었는지 확인
     LlmChannel saved = llmChannelMapper.findByUserId(TEST_USER_ID);
     assertThat(saved).isNotNull();
     assertThat(saved.getName()).isEqualTo("New LLM Channel");
     assertThat(saved.getPrompt()).isEqualTo("You are a helpful assistant.");
+    assertThat(saved.getGenerationType()).isEqualTo(ContentGenType.AUTO);
   }
 
   @DisplayName("성공_등록 시 기본값 처리 확인")
@@ -205,6 +214,7 @@ class LlmChannelServiceTest {
         .name("Minimal LLM Channel")
         .modelName("gpt-4")
         .apiKey("sk-minimal-key-12345678")
+        .generationType(ContentGenType.AUTO)
         // maxTokens, temperature, status는 null
         .build();
 
@@ -216,6 +226,7 @@ class LlmChannelServiceTest {
     assertThat(result.getMaxTokens()).isEqualTo(2000); // 기본값
     assertThat(result.getTemperature()).isEqualByComparingTo(new BigDecimal("0.7")); // 기본값
     assertThat(result.getStatus()).isTrue(); // 기본값
+    assertThat(result.getGenerationType()).isEqualTo(ContentGenType.AUTO);
   }
 
   @DisplayName("실패_이미 LLM 설정이 존재하면 BadRequestException 발생")
@@ -229,6 +240,7 @@ class LlmChannelServiceTest {
         .name("Duplicate Channel")
         .modelName("gpt-4")
         .apiKey("sk-duplicate-key-12345678")
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when & then
@@ -244,6 +256,7 @@ class LlmChannelServiceTest {
     LlmChannelCreateRequestDto createRequest = LlmChannelCreateRequestDto.builder()
         .name("Test LLM")
         .modelName("gpt-4")
+        .generationType(ContentGenType.AUTO)
         // apiKey가 null
         .build();
 
@@ -261,6 +274,7 @@ class LlmChannelServiceTest {
         .name("Test LLM")
         .modelName("gpt-4")
         .apiKey("   ") // 공백만 있는 경우
+        .generationType(ContentGenType.AUTO)
         .build();
 
     // when & then
@@ -279,6 +293,7 @@ class LlmChannelServiceTest {
         .maxTokens(2000)
         .temperature(new BigDecimal("0.7"))
         .prompt("Test prompt")
+        .generationType(ContentGenType.AUTO)
         .createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())
         .build();

--- a/src/test/java/com/final_team4/finalbe/user/service/UserServiceTest.java
+++ b/src/test/java/com/final_team4/finalbe/user/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import com.final_team4.finalbe._core.exception.ContentNotFoundException;
 import com.final_team4.finalbe._core.exception.DuplicateEmailException;
 import com.final_team4.finalbe._core.exception.UnauthorizedException;
 import com.final_team4.finalbe._core.security.JwtPrincipal;
+import com.final_team4.finalbe.content.domain.ContentGenType;
 import com.final_team4.finalbe.schedule.domain.ScheduleSetting;
 import com.final_team4.finalbe.schedule.mapper.ScheduleSettingMapper;
 import com.final_team4.finalbe.setting.domain.llm.LlmChannel;
@@ -86,6 +87,7 @@ class UserServiceTest {
         assertThat(defaultChannel.getMaxTokens()).isEqualTo(2000);
         assertThat(defaultChannel.getTemperature()).isEqualByComparingTo("0.9");
         assertThat(defaultChannel.getPrompt()).isEqualTo("설정 필요");
+        assertThat(defaultChannel.getGenerationType()).isEqualTo(ContentGenType.AUTO);
     }
 
     @DisplayName("회원가입 실패 - 이메일 중복 시 예외 발생")


### PR DESCRIPTION
## 🐰 Issue
> 닫을 issue 번호를 적어주세요.

resolved #118
<br>


## 🐷 Key Changes
> issue 이외의 변경 사항을 명시해주세요.
1. 회원가입할 때 llmChannel 테이블의 generationType 속성에 'AUTO' 기본값 자동 추가
2. 테스트 코드에서도 generationType 속성 추가
3. v11 sql 파일 추가
<br>


## 🐱 Branch
> 반영 branch -> dev

feat-118 -> dev
<br>


## 🐲 To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * LLM 채널에 생성 유형 설정 기능 추가 (자동/수동)
  * 채널 생성 및 업데이트 시 생성 유형 지정 가능
  * 신규 사용자 등록 시 기본 생성 유형은 자동으로 설정됨

* **데이터베이스**
  * LLM 채널 테이블에 생성 유형 필드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->